### PR TITLE
Require line should be in the new line

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -38,7 +38,7 @@ function header(text, dev=true) {
       ChunkInfo[filename].code = newCode;
       if (dev) {
         let index = String(text).lastIndexOf("\n");
-        let newText = text.slice(0, index) + `// @require file:///${path.join(__dirname, "/dist/" + FILE_NAME)}` + text.slice(index);
+        let newText = text.slice(0, index) + `\n// @require file:///${path.join(__dirname, "/dist/" + FILE_NAME)}` + text.slice(index);
         if (!fs.existsSync("dist")) {
           fs.mkdirSync("dist");
         }


### PR DESCRIPTION
Hey, I love this awesome work but I found one problem there.

When I directly change the header.js and run `npm run dev`, it compiled a .dev.js file in dist with:
```javascript
// ==UserScript==
// @name         svelte-tampermonkey-test
// @license      MIT
// @namespace    ckylin-test
// @version      v0.0.1
// @author       CKylinMC
// @match		 *://*.bilibili.com/*// @require file:///D:\Library\userscript\test-js-2\dist\main.user.js
// ==/UserScript==
```

The require line is in the same line with match tag, but it should be in a new line.

That's easily to be fixed with an extra \n character before the require line in vite.config.js:

```javascript
let newText = text.slice(0, index) + `\n// @require file:///${path.join(__dirname, "/dist/" + FILE_NAME)}` + text.slice(index);
```

and this time I got:

```
// ==UserScript==
// @name         svelte-tampermonkey-test
// @license      MIT
// @namespace    https://github.com/qianjiachun
// @version      2022.02.17.01
// @author       CKylinMC
// @match		 *://*.bilibili.com/*
// @require file:///D:\Library\userscript\test-js-2\dist\main.user.js
// ==/UserScript==
```

which is correct.